### PR TITLE
FIX: Add protocol separator to Site Address URL

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -19,7 +19,7 @@ if (getenv('NOW_URL')) {
 }
 
 define('WP_SITEURL', $protocol . '://' . $_SERVER['HTTP_HOST']);
-define('WP_HOME', $protocol . $_SERVER['HTTP_HOST']);
+define('WP_HOME', $protocol . '://' . $_SERVER['HTTP_HOST']);
 
 if ( !defined('ABSPATH') )
 	define('ABSPATH', dirname(__FILE__) . '/');


### PR DESCRIPTION
Add the separator to Site Address URL between protocol and hostname

Fixes https://github.com/now-examples/wordpress/issues/4